### PR TITLE
Optimize substring

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -27,7 +27,7 @@ final class Lexer
 
     public function __construct(#[Immutable] private string $json)
     {
-        $this->length = mb_strlen($this->json);
+        $this->length = strlen($this->json);
         $this->position = 0;
     }
 
@@ -218,7 +218,7 @@ final class Lexer
             }
         }
 
-        $lastCh = mb_substr($number, -1, 1);
+        $lastCh = $number[strlen($number) - 1];
         if ('0' <= $lastCh && $lastCh <= '9') {
             return new NumberToken($isFloat ? (float)$number : (int)$number);
         }
@@ -249,7 +249,7 @@ final class Lexer
 
     private function current(): string
     {
-        return mb_substr($this->json, $this->position, 1);
+        return $this->json[$this->position] ?? '';
     }
 
     private function consume(): ?string

--- a/tests/Lexer/LexerTest.php
+++ b/tests/Lexer/LexerTest.php
@@ -85,10 +85,10 @@ class LexerTest extends TestCase
             ],
             'string'           => [
                 [
-                    new StringToken("ab\"\\/\f\n\r\tc\\z好"),
+                    new StringToken("あab\"\\/\f\n\r\tc\\z好"),
                     new EofToken(),
                 ],
-                '"ab\"\\\/\f\n\r\tc\z\u597D"'
+                '"あab\"\\\/\f\n\r\tc\z\u597D"'
             ],
             'number'           => [
                 [


### PR DESCRIPTION
```
$ make bench-no-jit
docker-compose run --rm php-ci php -dopcache.enable=1 -dopcache.enable_cli=1 -dopcache.jit=0 -dopcache.jit_buffer_size=0 benchmark/bench.php
Creating php8-toy-json-parser_php-ci_run ... done
=== JsonParser : 0.722644
=== json_decode: 0.027997

$ make bench-jit
docker-compose run --rm php-ci php -dopcache.enable=1 -dopcache.enable_cli=1 -dopcache.jit=1 -dopcache.jit_buffer_size=100M benchmark/bench.php
Creating php8-toy-json-parser_php-ci_run ... done
=== JsonParser : 0.455727
=== json_decode: 0.026471
```